### PR TITLE
Make openafs-client a build-dep, not a runtime dep

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+debathena-machtype (10.5.4) unstable; urgency=low
+
+  * Make openafs-client a build-dep, not a runtime dependency, which it
+    was mistakenly converted to in 10.5 (Trac: #1543)
+
+ -- Jonathan Reed <jdreed@mit.edu>  Thu, 30 Oct 2014 12:21:45 -0400
+
 debathena-machtype (10.5.3) unstable; urgency=low
 
   * Depend on lsb-release (Trac: #1376)

--- a/debian/control
+++ b/debian/control
@@ -5,12 +5,12 @@ Maintainer: Debathena Project <debathena@mit.edu>
 Build-Depends: debhelper,
  lsb-release,
  python-minimal (>= 2.6~),
+ openafs-client (>= 1.4.12+dfsg-3~),
 Standards-Version: 3.9.3
 
 Package: debathena-machtype
 Architecture: any
-Depends: openafs-client (>= 1.4.12+dfsg-3~),
- lsb-release,
+Depends: lsb-release,
  ${shlibs:Depends},
  ${misc:Depends}
 Description: Print Athena machine type to standard output


### PR DESCRIPTION
Per (Trac: #1543), openafs-client was mistakenly converted to a
Dependency in 10.5, when it should be a Build Dependency.  The
postinst correctly checks for OpenAFS before attempting to set the
sysname
