### PR TITLE
Fix jessie build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+debathena-machtype (10.5.9) unstable; urgency=medium
+
+  * Fix build support for Jessie.
+
+ -- Victor Vasiliev <vasilvv@mit.edu>  Sat, 28 Nov 2015 15:41:25 -0500
+
 debathena-machtype (10.5.8) unstable; urgency=medium
 
   * Support Wily.

--- a/generate_sysnames.py
+++ b/generate_sysnames.py
@@ -52,6 +52,8 @@ ARCH = os.getenv('OVERRIDE_MACHTYPE_ARCH',
 
 MAX_SYSNAMES = 32
 
+if '+' in DEBIAN_VERSION:
+    DEBIAN_VERSION = DEBIAN_VERSION.split('+', 1)[0]
 if DEBIAN_VERSION.isdigit():
     DEBIAN_VERSION += ".0"
 


### PR DESCRIPTION
Currently, jessie base has version 8+deb8u2, which breaks the build
script.